### PR TITLE
Unify Start

### DIFF
--- a/Assets/Scenes/World.unity
+++ b/Assets/Scenes/World.unity
@@ -14,9 +14,9 @@ OcclusionCullingSettings:
 RenderSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 9
-  m_Fog: 0
+  m_Fog: 1
   m_FogColor: {r: 0.5294118, g: 0.80784315, b: 0.92156863, a: 1}
-  m_FogMode: 1
+  m_FogMode: 3
   m_FogDensity: 0.01
   m_LinearFogStart: 0
   m_LinearFogEnd: 300

--- a/Packages/io.codeblaze.vloxyengine/Runtime/Engine/Jobs/Data/ChunkDataScheduler.cs
+++ b/Packages/io.codeblaze.vloxyengine/Runtime/Engine/Jobs/Data/ChunkDataScheduler.cs
@@ -49,8 +49,6 @@ namespace CodeBlaze.Vloxy.Engine.Jobs.Data {
                 Allocator.Persistent
             );
 
-            new Queue<Chunk>();
-            
 #if VLOXY_LOGGING
             _Watch = new Stopwatch();
             _Timings = new Queue<long>(10);
@@ -63,30 +61,6 @@ namespace CodeBlaze.Vloxy.Engine.Jobs.Data {
         internal void Dispose() {
             _Jobs.Dispose();
             _Results.Dispose();
-        }
-
-        /// <summary>
-        /// Initial Generation
-        /// </summary>
-        /// <param name="jobs"></param>
-        internal void GenerateChunks(NativeArray<int3> jobs) {
-            var job = new ChunkDataJob {
-                Jobs = jobs,
-                ChunkSize = _ChunkSize,
-                NoiseProfile = _NoiseProfile,
-                Results = _Results.AsParallelWriter(),
-                BurstFunctionPointers = _BurstFunctionPointers,
-            };
-
-            var handle = job.Schedule(jobs.Length, 4);
-
-            handle.Complete();
-
-            _ChunkStore.AddChunks(_Results);
-            
-            _Results.Clear();
-            
-            jobs.Dispose();
         }
 
         internal void Start(List<int3> jobs) {

--- a/Packages/io.codeblaze.vloxyengine/Runtime/Engine/World/VloxyWorld.cs
+++ b/Packages/io.codeblaze.vloxyengine/Runtime/Engine/World/VloxyWorld.cs
@@ -75,8 +75,6 @@ namespace CodeBlaze.Vloxy.Engine.World {
 
         private void Start() {
             _IsFocused = _Focus != null;
-            
-            GenerateWorld();
 
             WorldStart();
         }
@@ -158,20 +156,6 @@ namespace CodeBlaze.Vloxy.Engine.World {
 
 #if VLOXY_LOGGING
             VloxyLogger.Info<VloxyWorld>("Vloxy Components Constructed");
-#endif
-        }
-
-        private void GenerateWorld() {
-#if VLOXY_LOGGING
-            var watch = new Stopwatch();
-            watch.Start();
-#endif
-            _ChunkDataScheduler.GenerateChunks(ChunkManager.InitialChunkRegion(Allocator.TempJob));
-            
-#if VLOXY_LOGGING
-            watch.Stop();
-            VloxyLogger.Info<VloxyWorld>($"Initial Chunks Generated : {ChunkManager.Store.ChunkCount()}");
-            VloxyLogger.Info<VloxyWorld>($"Vloxy World Generated : {watch.ElapsedMilliseconds} MS");
 #endif
         }
 


### PR DESCRIPTION
New scheduler handles start also, so we don't need initial chunk data generation, improving start-up times.

closes #89